### PR TITLE
Drop obsolete "max" option from datetime TCA

### DIFF
--- a/Configuration/TCA/tx_tinyurls_urls.php
+++ b/Configuration/TCA/tx_tinyurls_urls.php
@@ -85,7 +85,6 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => 10,
-                'max' => 20,
                 'eval' => 'datetime',
                 'default' => 0,
             ],


### PR DESCRIPTION
See https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.7/Deprecation-80027-RemoveTCAConfigMaxOnInputDateTimeFields.html