### PR TITLE
[BUGFIX] Add index on `valid_until` column

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -11,5 +11,6 @@ CREATE TABLE tx_tinyurls_urls (
 	delete_on_use tinyint(4) unsigned DEFAULT '0' NOT NULL,
 	valid_until int(11) unsigned DEFAULT '0' NOT NULL,
 	KEY target_url_hash (pid, target_url_hash),
+	KEY valid_until (valid_until ASC),
 	UNIQUE KEY tinyurl (pid, urlkey)
 );


### PR DESCRIPTION
This improves query performance when filtering or sorting by the `valid_until` column.

The new index ensures faster garbage collection of expired urls.

Resolves: #39